### PR TITLE
Fix minimax initialization

### DIFF
--- a/src/main/scala/morpion/Evaluation2.scala
+++ b/src/main/scala/morpion/Evaluation2.scala
@@ -141,9 +141,16 @@ object Evaluation2 {
 
 
 
-  def apply(tab: Array[Int], value: Int): Int ={
-    val tour = if(value==5) true else false
-    minimax2(new Origine(tab,tour),9, (tour,5)).pos
+  def apply(tab: Array[Int], value: Int): Int = {
+    // "tour" indique si le joueur courant utilise le symbole X (3) ou O (5).
+    //  true  -> joueur X
+    //  false -> joueur O
+    val tour = if (value == 3) true else false
+
+    // Le premier appel à minimax doit toujours chercher le meilleur coup pour
+    // le joueur courant, on se place donc dans le cas maximisant avec la
+    // valeur du joueur courant.
+    minimax2(new Origine(tab, tour), 9, (true, value)).pos
 
 
 


### PR DESCRIPTION
## Summary
- correct the player flag and parameters when calling `Evaluation2`'s minimax

## Testing
- `scalac -d out $(find src/main/scala -name '*.scala')`


------
https://chatgpt.com/codex/tasks/task_e_6840b07ce4c0832590d0c39a278d693e